### PR TITLE
Fixing split for client recv message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME = ircserv
 
 ### SETTINGS ###
-CXX := c++
+CXX := g++
 SRC_DIR := srcs/
 OBJ_DIR := objs/
 H_DIR := includes/

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -31,7 +31,7 @@ class Client : public AIO_Event
 		Client(void);
 
 		int _socket;
-		char buf[1024];
+		char buf[4];
 		std::string _messageStr;
 		Dispatch& _d;
 

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -31,7 +31,7 @@ class Client : public AIO_Event
 		Client(void);
 
 		int _socket;
-		char buf[4];
+		char buf[512];
 		std::string _messageStr;
 		Dispatch& _d;
 

--- a/includes/Utilities.hpp
+++ b/includes/Utilities.hpp
@@ -7,6 +7,7 @@
 class Utilities {
   public:
     static std::vector<std::string> split(const std::string& str, char delim);
+    static std::vector<std::string> clientSplit(const std::string& str, char delim);
 
   private:
     Utilities(void);

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -49,12 +49,12 @@ void Client::receive_message(void)
     if (std::find(_messageStr.begin(), _messageStr.end(), '\n') == _messageStr.end())
         return ;
 
-    std::vector<std::string> strVec = Utilities::split(_messageStr, '\n');
+    std::vector<std::string> strVec = Utilities::clientSplit(_messageStr, '\n');
     _messageStr.clear();
     for (std::vector<std::string>::iterator it = strVec.begin(); it != strVec.end(); it++) {
-        if (std::find(it->begin(), it->end(), '\r') != it->end())
+        if (std::find(it->begin(), it->end(), '\n') != it->end())
             // should call parsing function here rather than just printing.
-            std::cout << "Received(" << _socket << "): " << *it << std::endl;
+            std::cout << "Received(" << _socket << "): " << *it;
         else {
             std::cout << "\tAdded remainder: " << *it << std::endl;
             _messageStr = *it;

--- a/srcs/Utilities.cpp
+++ b/srcs/Utilities.cpp
@@ -15,3 +15,23 @@ std::vector<std::string> Utilities::split(const std::string& str, char delim) {
 
     return retVec;
 }
+
+std::vector<std::string> Utilities::clientSplit(const std::string& str, char delim) {
+    std::vector<std::string> retVec;
+    size_t start = 0;
+    size_t end = str.find(delim);
+
+    while (end != std::string::npos) {
+        // Include the delimiter in the substring
+        retVec.push_back(str.substr(start, end - start + 1));
+        start = end + 1;
+        end = str.find(delim, start);
+    }
+
+    // Add the remaining part of the string, if any
+    if (start < str.length()) {
+        retVec.push_back(str.substr(start));
+    }
+
+    return retVec;
+}

--- a/srcs/Utilities.cpp
+++ b/srcs/Utilities.cpp
@@ -1,5 +1,7 @@
 #include "Utilities.hpp"
 
+#include <iostream>
+
 Utilities::~Utilities(void) {}
 
 std::vector<std::string> Utilities::split(const std::string& str, char delim) {


### PR DESCRIPTION
Fixed the issue where we would drop a \n in the split function. now when a transmition comes through if the buffer is too small or if the buffer contains multiple transmittions, both are handled.