### PR TITLE
Fix memory issue with disconnect

### DIFF
--- a/includes/AIO_Event.hpp
+++ b/includes/AIO_Event.hpp
@@ -10,7 +10,7 @@ class AIO_Event {
     virtual void send_message(std::string message) = 0;
     virtual void receive_message(void) = 0;
     virtual int getSocket(void) const = 0;
+    virtual bool shouldDelete(void) const = 0;
 
-    private:
-
+  private:
 };

--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -37,10 +37,6 @@ class Channel {
 		bool checkInvite(Client *client);
 		void addInvite(Client *client);
 		void removeInvite(Client *client);
-		// Ban methods
-		bool checkBan(Client *client);
-		void addBan(Client *client);
-		void removeBan(Client *client);
 
 		// Getters //
 		std::string getName(void) const;
@@ -61,7 +57,6 @@ class Channel {
 		std::string _topic;
 		std::map<Client *, bool> _clients;
 		int _maxClients;
-		std::set<Client *> _bans;
 		std::set<Client *> _invites;
 
 		// Mode flags

--- a/includes/ChannelManager.hpp
+++ b/includes/ChannelManager.hpp
@@ -15,6 +15,7 @@ class ChannelManager {
 
     void addChannel(std::string name, Client *client = NULL);
     void removeChannel(std::string name);
+		void removeClientFromAllChannels(Client *client);
 
     // Getters //
     size_t getNumChannels(void);
@@ -22,10 +23,6 @@ class ChannelManager {
     Channel *getChannel(std::string name);
 		int getClientChannelCount(Client *client);
     int getMaxChannelsForClient(void);
-
-    // To be implemented
-		// void removeClientFromAllChannels(Client *client);
-			// remove the client from the channel map
 
   private:
     std::set<Channel *> _channels;

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -29,6 +29,7 @@ class Client : public AIO_Event
 		// METHODS
 		void send_message(std::string message);
 		void receive_message(void);
+		bool shouldDelete(void) const;
 
 		//GETTERS & SETTERS
 		int getSocket(void) const;
@@ -56,5 +57,6 @@ class Client : public AIO_Event
 		std::string _username;
 		std::string _realname;
 		std::string _nickname;
+		bool _shouldDelete;
 
 };

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -24,6 +24,9 @@ class Server : public AIO_Event
 		// METHODS
 		void send_message(std::string message);
 		void receive_message(void);
+		bool shouldDelete(void) const;
+
+		// Getter
 		int getSocket(void) const;
 
 	private:
@@ -36,4 +39,5 @@ class Server : public AIO_Event
 		Dispatch& _d;
 		std::set<Client *>& _clients;
 		ChannelManager& _cm;
+		bool _shouldDelete;
 };

--- a/srcs/Channel.cpp
+++ b/srcs/Channel.cpp
@@ -108,20 +108,6 @@ void Channel::removeInvite(Client *client) {
     _invites.erase(client);
 };
 
-// Ban methods
-
-bool Channel::checkBan(Client *client) {
-    return (_bans.find(client) != _bans.end());
-};
-
-void Channel::addBan(Client *client) {
-    _bans.insert(client);
-};
-
-void Channel::removeBan(Client *client) {
-    _bans.erase(client);
-};
-
 /**********************************************************/
 /*                        GETTERS                         */
 /**********************************************************/

--- a/srcs/ChannelManager.cpp
+++ b/srcs/ChannelManager.cpp
@@ -44,6 +44,18 @@ void ChannelManager::removeChannel(std::string name) {
   }
 };
 
+
+void ChannelManager::removeClientFromAllChannels(Client *client) {
+  if (client == NULL) {
+    return;
+  }
+
+  for (std::set<Channel *>::iterator it = _channels.begin(); it != _channels.end(); it++) {
+    (*it)->removeInvite(client);
+    (*it)->removeClient(client);
+  }
+};
+
 // GETTERS //
 
 size_t ChannelManager::getNumChannels(void) {

--- a/srcs/Command.cpp
+++ b/srcs/Command.cpp
@@ -134,11 +134,7 @@ void Command::handle_JOIN() {
         // channel exists. start channel checks
         std::cout << "Channel exists" << std::endl;
         // check that user is not banned from channel
-            // Can leave this in? But not required by subject.
-        if (chan->checkBan(&_client)) {
-            std::cout << "User is banned" << std::endl;
-            throw CommandException(ERR_BANNEDFROMCHAN());
-        }
+            // This is a check in the protocol but not required by the subject.
         // check that the channel is not invite only
         if (chan->getInviteOnly()) {
             if (chan->checkInvite(&_client)) {
@@ -153,8 +149,8 @@ void Command::handle_JOIN() {
             std::cout << "Channel is full" << std::endl;
             throw CommandException(ERR_CHANNELISFULL());
         }
-        // check that the channel mask is good ???
-            // This is listed as a future feature so ignore for now
+        // check that the channel mask is good
+            // This is in the protocol for ops only. Not required by the subject.
         // check password
         if (chan->requiresKey()) {
             // Channel requires a password

--- a/srcs/Dispatch.cpp
+++ b/srcs/Dispatch.cpp
@@ -44,6 +44,9 @@ void Dispatch::run(void) {
     AIO_Event *event = static_cast<AIO_Event *>(_events[i].data.ptr);
     if (_events[i].events & EPOLLIN) {
       event->receive_message();
+      if (event->shouldDelete()) {
+        delete event;
+      }
     }
     if (_events[i].events & EPOLLOUT) {
       event->send_message("");

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -8,7 +8,7 @@
 
 Server::Server(Dispatch& d, int port, 
     std::set<Client *> & clients, ChannelManager & cm)
-    : _port(port), _d(d), _clients(clients), _cm(cm)
+    : _port(port), _d(d), _clients(clients), _cm(cm), _shouldDelete(false)
 {
     //Creating server socket
     _socket = socket(AF_INET, SOCK_STREAM, 0);
@@ -89,7 +89,10 @@ void Server::receive_message(void)
 }
 
 
-int Server::getSocket(void) const
-{
+int Server::getSocket(void) const {
     return _socket;
+};
+
+bool Server::shouldDelete(void) const {
+    return (_shouldDelete);
 };


### PR DESCRIPTION
fixed the issue where clients are allocated one time and left in the client set until the server shuts down. 
down when a client disconnects, we destroy the client class for that socket, and if the server shuts down, the open clients are each handled as well.