### PR TITLE
Fix empty channels

### DIFF
--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -28,6 +28,7 @@ class Channel {
 		void promoteClient(Client *client);
 		bool checkCanAddMoreClients(void);
 		bool shouldDelete(void);
+		bool checkIfClientInChannel(Client *client);
 		// Message methods
 		void forwardMessage(std::string message, Client *sender);
 		// Key methods

--- a/includes/ChannelManager.hpp
+++ b/includes/ChannelManager.hpp
@@ -18,6 +18,8 @@ class ChannelManager {
 		void removeClientFromAllChannels(Client *client);
     void removeClientFromChannel(std::string name, Client *client);
     void removeEmptyChannels();
+    bool checkIfChannelExists(std::string name);
+    bool checkIfClientInChannel(std::string name, Client *client);
 
     // Getters //
     size_t getNumChannels(void);

--- a/includes/ChannelManager.hpp
+++ b/includes/ChannelManager.hpp
@@ -16,6 +16,8 @@ class ChannelManager {
     void addChannel(std::string name, Client *client = NULL);
     void removeChannel(std::string name);
 		void removeClientFromAllChannels(Client *client);
+    void removeClientFromChannel(std::string name, Client *client);
+    void removeEmptyChannels();
 
     // Getters //
     size_t getNumChannels(void);

--- a/includes/ChannelManager.hpp
+++ b/includes/ChannelManager.hpp
@@ -16,9 +16,7 @@ class ChannelManager {
     void addChannel(std::string name, Client *client = NULL);
     void removeChannel(std::string name);
 		void removeClientFromAllChannels(Client *client);
-    void removeClientFromChannel(std::string name, Client *client);
     void removeEmptyChannels();
-    bool checkIfChannelExists(std::string name);
     bool checkIfClientInChannel(std::string name, Client *client);
 
     // Getters //

--- a/srcs/Channel.cpp
+++ b/srcs/Channel.cpp
@@ -75,6 +75,10 @@ bool Channel::shouldDelete(void) {
     return (_clients.size() == 0);
 };
 
+bool Channel::checkIfClientInChannel(Client *client) {
+    return (_clients.find(client) != _clients.end());
+};
+
 // Message methods
 
 void Channel::forwardMessage(std::string message, Client *sender) {

--- a/srcs/Channel.cpp
+++ b/srcs/Channel.cpp
@@ -11,7 +11,9 @@ Channel::Channel(std::string name)
 Channel::Channel(const Channel & src) 
     : _name(src._name), _key(src._key), _maxClients(-1) {}
 
-Channel::~Channel() {}
+Channel::~Channel() {
+    std::cout << "Channel destructor called" << std::endl;
+}
 
 
 /**********************************************************/

--- a/srcs/ChannelManager.cpp
+++ b/srcs/ChannelManager.cpp
@@ -38,10 +38,27 @@ void ChannelManager::removeChannel(std::string name) {
   // Look for channel by name
   for (std::set<Channel *>::iterator it = _channels.begin(); it != _channels.end(); it++) {
     if ((*it)->getName() == name) {
+      _channels.erase(*it);
       delete *it;
       return;
     }
   }
+};
+
+void ChannelManager::removeEmptyChannels() {
+  std::vector<Channel *> channelsToDelete;
+
+  for (std::set<Channel *>::iterator it = _channels.begin(); it != _channels.end(); it++) {
+    if ((*it)->getChanSize() == 0) {
+      channelsToDelete.push_back(*it);
+    }
+  }
+
+  for (std::vector<Channel *>::iterator it = channelsToDelete.begin(); it != channelsToDelete.end(); it++) {
+    _channels.erase(*it);
+    delete *it;
+  }
+
 };
 
 
@@ -53,6 +70,27 @@ void ChannelManager::removeClientFromAllChannels(Client *client) {
   for (std::set<Channel *>::iterator it = _channels.begin(); it != _channels.end(); it++) {
     (*it)->removeInvite(client);
     (*it)->removeClient(client);
+  }
+  removeEmptyChannels();
+  std::cout << "returning from removeClientFromAllChannels\n";
+};
+
+void ChannelManager::removeClientFromChannel(std::string name, Client *client) {
+  if (client == NULL) {
+    return;
+  }
+
+  for (std::set<Channel *>::iterator it = _channels.begin(); it != _channels.end(); it++) {
+    // Look for channel by name and remove client
+    if ((*it)->getName() == name) {
+      std::cout << "found channel: " << name << " and will remove client\n";
+      (*it)->removeInvite(client);
+      (*it)->removeClient(client);
+      if ((*it)->getChanSize() == 0) {
+        removeChannel((*it)->getName());
+      }
+      return;
+    }
   }
 };
 

--- a/srcs/ChannelManager.cpp
+++ b/srcs/ChannelManager.cpp
@@ -61,7 +61,6 @@ void ChannelManager::removeEmptyChannels() {
 
 };
 
-
 void ChannelManager::removeClientFromAllChannels(Client *client) {
   if (client == NULL) {
     return;
@@ -72,36 +71,6 @@ void ChannelManager::removeClientFromAllChannels(Client *client) {
     (*it)->removeClient(client);
   }
   removeEmptyChannels();
-  std::cout << "returning from removeClientFromAllChannels\n";
-};
-
-void ChannelManager::removeClientFromChannel(std::string name, Client *client) {
-  if (client == NULL) {
-    return;
-  }
-
-  for (std::set<Channel *>::iterator it = _channels.begin(); it != _channels.end(); it++) {
-    // Look for channel by name and remove client
-    if ((*it)->getName() == name) {
-      std::cout << "found channel: " << name << " and will remove client\n";
-      (*it)->removeInvite(client);
-      (*it)->removeClient(client);
-      if ((*it)->getChanSize() == 0) {
-        removeChannel((*it)->getName());
-      }
-      return;
-    }
-  }
-};
-
-bool ChannelManager::checkIfChannelExists(std::string name) {
-  // Look for channel by name
-  for (std::set<Channel *>::iterator it = _channels.begin(); it != _channels.end(); it++) {
-    if ((*it)->getName() == name) {
-      return true;
-    }
-  }
-  return false;
 };
 
 bool ChannelManager::checkIfClientInChannel(std::string name, Client *client) {

--- a/srcs/ChannelManager.cpp
+++ b/srcs/ChannelManager.cpp
@@ -94,6 +94,26 @@ void ChannelManager::removeClientFromChannel(std::string name, Client *client) {
   }
 };
 
+bool ChannelManager::checkIfChannelExists(std::string name) {
+  // Look for channel by name
+  for (std::set<Channel *>::iterator it = _channels.begin(); it != _channels.end(); it++) {
+    if ((*it)->getName() == name) {
+      return true;
+    }
+  }
+  return false;
+};
+
+bool ChannelManager::checkIfClientInChannel(std::string name, Client *client) {
+  // Look for channel by name
+  for (std::set<Channel *>::iterator it = _channels.begin(); it != _channels.end(); it++) {
+    if ((*it)->getName() == name) {
+      return (*it)->checkIfClientInChannel(client);
+    }
+  }
+  return false;
+};
+
 // GETTERS //
 
 size_t ChannelManager::getNumChannels(void) {

--- a/srcs/Command.cpp
+++ b/srcs/Command.cpp
@@ -239,30 +239,21 @@ void Command::handle_NICK()
 
 void Command::handle_NOTICE() {}
 void Command::handle_PART() {
-    // Initial error checking
     if (_parameters.size() <= 1)
         throw CommandException(ERR_NEEDMOREPARAMS(_cmd));
 
-    // Split parameters by space
     std::vector<std::string> params = Utilities::split(_parameters, ' ');
 
     ChannelManager& cm = _client.getCM();
     Channel *chan = cm.getChannel(params[0]);
 
     if (chan != NULL) {
-        // Channel exists
-        std::cout << "Channel exists" << std::endl;
         if (chan->checkIfClientInChannel(&_client)) {
-            std::cout << "Client is in channel" << std::endl;
             chan->removeClient(&_client);
-            std::cout << "new channel size: " << chan->getChanSize() << std::endl;
         } else {
-            std::cout << "Client is not in channel" << std::endl;
             throw CommandException(ERR_NOTONCHANNEL(params[0]));
         }
     } else {
-        // Channel does not exist
-        std::cout << "Channel does not exist" << std::endl;
         throw CommandException(ERR_NOSUCHCHANNEL(params[0]));
     }
     cm.removeEmptyChannels();
@@ -294,6 +285,11 @@ void Command::handle_PRIVMSG() {
         // Channel
         ChannelManager& cm = _client.getCM();
         Channel *chan = cm.getChannel(recipeints);
+
+
+// NOTE We need to check that a user is in a channel before sending 
+// a message to that channel.
+
         if (chan != NULL) {
             // Channel exists
             std::cout << "Channel exists" << std::endl;

--- a/srcs/Command.cpp
+++ b/srcs/Command.cpp
@@ -293,8 +293,13 @@ void Command::handle_PRIVMSG() {
         if (chan != NULL) {
             // Channel exists
             std::cout << "Channel exists" << std::endl;
-            // Send message to all clients in channel
-            chan->forwardMessage(message, &_client);
+            if (!chan->checkIfClientInChannel(&_client)) {
+                // Send message to all clients in channel
+                chan->forwardMessage(message, &_client);
+            } else {
+                // User is not in channel
+                throw CommandException(ERR_CANNOTSENDTOCHAN(recipeints));
+            }
         } else {
             // Channel does not exist
             std::cout << "Channel does not exist" << std::endl;

--- a/srcs/Command.cpp
+++ b/srcs/Command.cpp
@@ -171,7 +171,7 @@ void Command::handle_JOIN() {
         std::cout << "Channel does not exist, creating channel" << std::endl;
         cm.addChannel(params[0], &_client);
     }
-    // std::cout << "Number of channels: " << cm.getNumChannels() << std::endl;
+    std::cout << "Number of channels: " << cm.getNumChannels() << std::endl;
 }
 
 void Command::handle_LIST() {}

--- a/srcs/Command.cpp
+++ b/srcs/Command.cpp
@@ -238,7 +238,35 @@ void Command::handle_NICK()
 
 
 void Command::handle_NOTICE() {}
-void Command::handle_PART() {}
+void Command::handle_PART() {
+    // Initial error checking
+    if (_parameters.size() <= 1)
+        throw CommandException(ERR_NEEDMOREPARAMS(_cmd));
+
+    // Split parameters by space
+    std::vector<std::string> params = Utilities::split(_parameters, ' ');
+
+    ChannelManager& cm = _client.getCM();
+    Channel *chan = cm.getChannel(params[0]);
+
+    if (chan != NULL) {
+        // Channel exists
+        std::cout << "Channel exists" << std::endl;
+        if (chan->checkIfClientInChannel(&_client)) {
+            std::cout << "Client is in channel" << std::endl;
+            chan->removeClient(&_client);
+            std::cout << "new channel size: " << chan->getChanSize() << std::endl;
+        } else {
+            std::cout << "Client is not in channel" << std::endl;
+            throw CommandException(ERR_NOTONCHANNEL(params[0]));
+        }
+    } else {
+        // Channel does not exist
+        std::cout << "Channel does not exist" << std::endl;
+        throw CommandException(ERR_NOSUCHCHANNEL(params[0]));
+    }
+    cm.removeEmptyChannels();
+}
 
 void Command::handle_PING()
 {


### PR DESCRIPTION
Channels will now auto delete when the last Client leaves. It does this by removing the pointer to the client from all channels and then doing a final check where if there are empty channels, they are deleted at the end.