### PR TITLE
Who command

### DIFF
--- a/includes/Command.hpp
+++ b/includes/Command.hpp
@@ -83,6 +83,7 @@ class Command
 		bool handle_MODE_k(bool posFlag, Channel *chan, std::string arg);
 		bool handle_MODE_o(bool posFlag, Channel *chan, std::string arg);
 		bool handle_MODE_l(bool posFlag, Channel *chan, std::string arg);
+		bool handle_MODE_b(Channel *chan);
 
 		Client * getMatchingClient(std::string & username) const;
 		Channel * getMatchingChannel(std::string & username, std::set<Channel *> & channels) const;

--- a/includes/ServerReplies.hpp
+++ b/includes/ServerReplies.hpp
@@ -79,3 +79,6 @@
 #define RPL_ENDOFNAMES(nick, channel) (":ft_irc 366 " + nick + " " + channel + " :End of /NAMES list.\r\n")
 // >> :*.freenode.net 324 yo1 #heythereguys :+nt$
 #define RPL_CHANNELMODEIS(nick, channel, mode) (":ft_irc 324 " + nick + " " + channel + " :" + mode + "\r\n")
+#define RPL_WHOREPLY(nick, channel, user, host, server, mode, hopCount, realName) (":ft_irc 352 " + nick + " " + channel + " " + user + " " + host + " " + server + " " + nick + " " + mode + " " + hopCount + " :" + realName + "\r\n")
+#define RPL_ENDOFWHO(nick, channel) (":ft_irc 315 " + nick + " " + channel + " :End of /WHO list.\r\n")
+#define RPL_ENDOFBANLIST(nick, channel) (":ft_irc 368 " + nick + " " + channel + " :End of channel ban list\r\n")

--- a/includes/ServerReplies.hpp
+++ b/includes/ServerReplies.hpp
@@ -79,6 +79,6 @@
 #define RPL_ENDOFNAMES(nick, channel) (":ft_irc 366 " + nick + " " + channel + " :End of /NAMES list.\r\n")
 // >> :*.freenode.net 324 yo1 #heythereguys :+nt$
 #define RPL_CHANNELMODEIS(nick, channel, mode) (":ft_irc 324 " + nick + " " + channel + " :" + mode + "\r\n")
-#define RPL_WHOREPLY(nick, channel, user, host, server, mode, hopCount, realName) (":ft_irc 352 " + nick + " " + channel + " " + user + " " + host + " " + server + " " + nick + " " + mode + " " + hopCount + " :" + realName + "\r\n")
+#define RPL_WHOREPLY(nick, channel, user, host, server, mode, hopCount, realName) (":ft_irc 352 " + nick + " " + channel + " " + user + " " + host + " " + server + " " + nick + " " + mode + " :" + hopCount + " " + realName + "\r\n")
 #define RPL_ENDOFWHO(nick, channel) (":ft_irc 315 " + nick + " " + channel + " :End of /WHO list.\r\n")
 #define RPL_ENDOFBANLIST(nick, channel) (":ft_irc 368 " + nick + " " + channel + " :End of channel ban list\r\n")

--- a/srcs/Channel.cpp
+++ b/srcs/Channel.cpp
@@ -33,15 +33,11 @@ Channel & Channel::operator=(const Channel & src)
 
 // Client methods
 
-// >> :yo1!~dpentlan@freenode-26o.s40.6vib9m.IP JOIN :#heythereguys$
-
-
-
 void Channel::addClient(Client *client) {
     if (client == NULL)
         return ;
 
-    if (_clients.size() != true)
+    if (_clients.size() == 0)
         // add the client as a channel operator
         _clients.insert(std::make_pair(client, true));
     else
@@ -101,8 +97,7 @@ void Channel::forwardMessage(std::string message, Client *sender) {
     for (std::map<Client*, bool>::iterator it = _clients.begin(); it != _clients.end(); ++it) {
         if (it->first != sender) {
             std::cout << "Sending message to client: " << it->first->getSocket() << std::endl;
-            it->first->send_message(":" \
-                + sender->getNickname() + " PRIVMSG " + _name + " :" \
+            it->first->send_message(sender->getPrefix() + " PRIVMSG " + _name + " :" \
                 + message + "\r\n");
         }
     }
@@ -194,7 +189,7 @@ std::string Channel::getClientNicknames(void) {
     std::ostringstream ss;
     for (std::map<Client*, bool>::iterator it = _clients.begin(); it != _clients.end(); ++it) {
         if (it != _clients.begin())
-            ss << ", ";
+            ss << " ";
         if (it->second)
             ss << "@";
         ss << it->first->getNickname();

--- a/srcs/Command.cpp
+++ b/srcs/Command.cpp
@@ -289,7 +289,7 @@ void Command::handle_MODE() {
     
     // Check if the mode is a ban mode request (we only repond to irssi during join)
     size_t pos = paramsVec[1].find('b');
-    if (pos != std::string::npos && pos == 0) {
+    if (pos != std::string::npos && pos == 0 && paramsVec[1].size() == 1) {
         handle_MODE_b(chan);
         return ;
     }
@@ -688,16 +688,6 @@ Yowzaa!!! \n\
 }
 
 void Command::handle_WHO() {
-    // << WHO #heythereguys$
-    // >> :*.freenode.net 329 yo1 #heythereguys :1721559632$
-    // --> event 329$
-    // >> :*.freenode.net 352 yo1 #heythereguys ~dpentlan freenode-26o.s40.6vib9m.IP *.freenode.net yo1 H :0 Drew PENTLAND$
-    // --> silent event who$
-    // >> :*.freenode.net 352 yo1 #heythereguys ~dpentlan freenode-26o.s40.6vib9m.IP *.freenode.net yo3__ H@ :0 Drew PENTLAND$
-    // --> silent event who$
-    // >> :*.freenode.net 315 yo1 #heythereguys :End of /WHO list.$
-    // --> chanquery who end$
-
     // input error checking (need parameters, and should be a channel, and user should be on the channel)
     if (_parameters.size() <= 1)
         throw CommandException(ERR_NEEDMOREPARAMS(_cmd));
@@ -727,7 +717,6 @@ void Command::handle_WHO() {
 
 void Command::handle_WHOIS() {}
 void Command::handle_WHOWAS() {}
-
 
 // Mode flags
 


### PR DESCRIPTION
Added WHO command to complete the JOIN sequence.
JOIN has several steps including the initial request,
a response where the server tells the user the channel and which users are in the chat with which status (op or not), 
Then the client requests with MODE the current mode of the channel, 
Then the WHO command is called where we give the client all the information for the users in the channel including username, hostname, server, status, hopcount, and real name
then we say end of the who list, 
then the client asks for the ban list
We always respond with nothing for now since we do not use a ban list.
then the join sequence is complete.
After this pr, we should be finished with this unless other issues are found in the future.